### PR TITLE
Fix a few more docs typos, try to get travis-ci to ignore so build wi…

### DIFF
--- a/doc/getting_started/beginner_tutorial.rst
+++ b/doc/getting_started/beginner_tutorial.rst
@@ -300,7 +300,7 @@ And you can view the generated montage image via:
 Exploring your DAG in the Pachyderm dashboard
 --------------------------------------------
 
-When you deployed Pachyderm locally, the Pachyderm Enterprise dashboard was also deployed by default. This dashboard will let you interactively explore your pipeline, visualize the structure of the pipeline, explore your data, debug jobs, etc. To access the dashboard visit ``localhost:30080`` in an Internet browser (e.g., Google Chrome). You should see something similar to this:
+When you deployed Pachyderm locally, the Pachyderm Enterprise dashboard was also deployed by default. This dashboard will let you interactively explore your DAG (directed acyclic graph), visualize the structure of the pipeline, explore your data, debug jobs, etc. To access the dashboard visit ``localhost:30080`` in an Internet browser (e.g., Google Chrome). You should see something similar to this:
 
 .. image:: dashboard1.png
 
@@ -319,4 +319,4 @@ Pachyderm is now running locally with data and a pipeline! To play with Pachyder
 - :doc:`../fundamentals/getting_data_into_pachyderm`
 - :doc:`../fundamentals/creating_analysis_pipelines`
 
-We'd love to help and see what you come up with, so submit any issues/questions you come across on `GitHub <https://github.com/pachyderm/pachyderm>`_ , `Slack <http://slack.pachyderm.io>`_ or email at support@pachyderm.io if you want to show off anything nifty you've created!
+We'd love to help and see what you come up with, so submit any issues/questions you come across on `GitHub <https://github.com/pachyderm/pachyderm>`_, `Slack <http://slack.pachyderm.io>`_, or email at support@pachyderm.io if you want to show off anything nifty you've created!


### PR DESCRIPTION
…ll pass [ci skip]

Travis-CI is failing because enterprise token not present. Not relevant for changing a markdown doc file. Hoping that putting [ci-skip] in the commit message instead of the commit description will result in the TravisCI build tests actually getting skipped.